### PR TITLE
Update angular-soundmanager2.js

### DIFF
--- a/dist/angular-soundmanager2.js
+++ b/dist/angular-soundmanager2.js
@@ -6475,7 +6475,7 @@ angular.module('angularSoundManager', [])
 
                     var sound = soundManager.getSoundById(angularPlayer.getCurrentTrack());
 
-                    var x = event.x - element[0].offsetLeft,
+                    var x = event.offsetX,
                         width = element[0].clientWidth,
                         duration = sound.durationEstimate;
 


### PR DESCRIPTION
Fixed the progress bar offset width. Songs will now seek to the correct position selected on the progress bar.
